### PR TITLE
Refactoring and one bugfix

### DIFF
--- a/cmd/dinspect/main.go
+++ b/cmd/dinspect/main.go
@@ -48,7 +48,7 @@ func dumpFile(filepath string) {
 		}
 
 		msgType := msg.MsgType().String()
-        fmt.Printf("%-10s %s\n", msgType + ":", msg.String())
+		fmt.Printf("%-10s %s\n", msgType+":", msg.String())
 	}
 
 	if err := d.Close(); err != nil {

--- a/cmd/dumper/dumper.go
+++ b/cmd/dumper/dumper.go
@@ -90,7 +90,7 @@ func main() {
 
 //HandleMessage processes message
 func (d *dumper) HandleMessage(msg message.Message, lsn dbutils.LSN) error {
-    log.Printf("%-18s %-10s: %s", lsn.String(), msg.MsgType(), msg.String());
+	log.Printf("%-18s %-10s: %s", lsn.String(), msg.MsgType(), msg.String())
 
 	if msg.MsgType() == message.MsgCommit {
 		d.consumer.AdvanceLSN(lsn)

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -61,18 +61,18 @@ func (d *decoder) rowInfo(char byte) bool {
 	}
 }
 
-func (d *decoder) tupledata() []message.Tuple {
+func (d *decoder) tupledata() []message.TupleData {
 	size := int(d.uint16())
-	data := make([]message.Tuple, size)
+	data := make([]message.TupleData, size)
 	for i := 0; i < size; i++ {
 		switch d.buf.Next(1)[0] {
 		case 'n':
-			data[i] = message.Tuple{Kind: message.TupleNull, Value: []byte{}}
+			data[i] = message.TupleData{Kind: message.TupleNull, Value: []byte{}}
 		case 'u':
-			data[i] = message.Tuple{Kind: message.TupleToasted, Value: []byte{}}
+			data[i] = message.TupleData{Kind: message.TupleToasted, Value: []byte{}}
 		case 't':
 			vsize := int(d.order.Uint32(d.buf.Next(4)))
-			data[i] = message.Tuple{Kind: message.TupleText, Value: d.buf.Next(vsize)}
+			data[i] = message.TupleData{Kind: message.TupleText, Value: d.buf.Next(vsize)}
 		}
 	}
 
@@ -96,123 +96,101 @@ func (d *decoder) columns() []message.Column {
 // Parse a logical replication message.
 // See https://www.postgresql.org/docs/current/static/protocol-logicalrep-message-formats.html
 func Parse(src []byte) (message.Message, error) {
+	var msg message.Message
+
 	msgType := src[0]
 	d := &decoder{order: binary.BigEndian, buf: bytes.NewBuffer(src[1:])}
+
 	switch msgType {
 	case 'B':
-		m := message.Begin{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		b := &message.Begin{}
 
-		m.FinalLSN = d.lsn()
-		m.Timestamp = d.timestamp()
-		m.XID = d.int32()
+		b.FinalLSN = d.lsn()
+		b.Timestamp = d.timestamp()
+		b.XID = d.int32()
+		msg = b
 
-		return m, nil
 	case 'C':
-		m := message.Commit{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		c := &message.Commit{}
 
-		m.Flags = d.uint8()
-		m.LSN = d.lsn()
-		m.TransactionLSN = d.lsn()
-		m.Timestamp = d.timestamp()
+		c.Flags = d.uint8()
+		c.LSN = d.lsn()
+		c.TransactionLSN = d.lsn()
+		c.Timestamp = d.timestamp()
+		msg = c
 
-		return m, nil
 	case 'O':
-		m := message.Origin{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		o := &message.Origin{}
+		o.LSN = d.lsn()
+		o.Name = d.string()
+		msg = o
 
-		m.LSN = d.lsn()
-		m.Name = d.string()
-
-		return m, nil
 	case 'R':
-		m := message.Relation{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		r := &message.Relation{}
 
-		m.OID = d.oid()
-		m.Namespace = d.string()
-		m.Name = d.string()
-		m.ReplicaIdentity = message.ReplicaIdentity(d.uint8())
-		m.Columns = d.columns()
+		r.OID = d.oid()
+		r.Namespace = d.string()
+		r.Name = d.string()
+		r.ReplicaIdentity = message.ReplicaIdentity(d.uint8())
+		r.Columns = d.columns()
+		msg = r
 
-		return m, nil
 	case 'Y':
-		m := message.Type{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		t := &message.Type{}
 
-		m.OID = d.oid()
-		m.Namespace = d.string()
-		m.Name = d.string()
+		t.OID = d.oid()
+		t.Namespace = d.string()
+		t.Name = d.string()
+		msg = t
 
-		return m, nil
 	case 'I':
-		m := message.Insert{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		i := &message.Insert{}
 
-		m.RelationOID = d.oid()
-		m.IsNew = d.uint8() == 'N'
-		m.NewRow = d.tupledata()
+		i.RelationOID = d.oid()
+		i.IsNew = d.uint8() == 'N'
+		i.NewRow = d.tupledata()
+		msg = i
 
-		return m, nil
 	case 'U':
-		m := message.Update{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		u := &message.Update{}
 
-		m.RelationOID = d.oid()
-		m.IsKey = d.rowInfo('K')
-		m.IsOld = d.rowInfo('O')
-		if m.IsKey || m.IsOld {
-			m.OldRow = d.tupledata()
+		u.RelationOID = d.oid()
+		u.IsKey = d.rowInfo('K')
+		u.IsOld = d.rowInfo('O')
+		if u.IsKey || u.IsOld {
+			u.OldRow = d.tupledata()
 		}
-		m.IsNew = d.uint8() == 'N'
-		m.NewRow = d.tupledata()
+		u.IsNew = d.uint8() == 'N'
+		u.NewRow = d.tupledata()
+		msg = u
 
-		return m, nil
 	case 'D':
-		m := message.Delete{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		m := &message.Delete{}
 
 		m.RelationOID = d.oid()
 		m.IsKey = d.rowInfo('K')
 		m.IsOld = d.rowInfo('O')
 		m.OldRow = d.tupledata()
+		msg = m
 
-		return m, nil
 	case 'T':
-		m := message.Truncate{
-			Raw: make([]byte, len(src)),
-		}
-		copy(m.Raw, src)
+		t := &message.Truncate{}
 
 		relationsCnt := int(d.uint32())
 		options := d.uint8()
-		m.Cascade = options&truncateCascadeBit == 1
-		m.RestartIdentity = options&truncateRestartIdentityBit == 1
+		t.Cascade = options&truncateCascadeBit == 1
+		t.RestartIdentity = options&truncateRestartIdentityBit == 1
 
-		m.RelationOIDs = make([]dbutils.OID, relationsCnt)
+		t.RelationOIDs = make([]dbutils.OID, relationsCnt)
 		for i := 0; i < relationsCnt; i++ {
-			m.RelationOIDs[i] = d.oid()
+			t.RelationOIDs[i] = d.oid()
 		}
+		msg = t
 
-		return m, nil
 	default:
 		return nil, fmt.Errorf("unknown message type for %s (%d)", []byte{msgType}, msgType)
 	}
+
+	msg.SetRawData(src);
+	return msg, nil
 }

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -155,7 +155,8 @@ func Parse(src []byte) (message.Message, error) {
 
 		// Did we receive a marker of old tuple?
 		if char == 'K' || char == 'O' {
-			u.OldRow = d.tupledata()
+			u.Ident = d.tupledata()
+			u.IdentIsKey = (char == 'K')
 			char = d.uint8()
 		}
 
@@ -170,7 +171,8 @@ func Parse(src []byte) (message.Message, error) {
 		m.RelationOID = d.oid()
 		char := d.uint8()
 		if char == 'K' || char == 'O' {
-			m.OldRow = d.tupledata()
+			m.Ident = d.tupledata()
+			m.IdentIsKey = (char == 'K')
 		}
 		return m, nil
 

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -98,7 +98,7 @@ func Parse(src []byte) (message.Message, error) {
 	// checks.
 	switch msgType {
 	case 'B':
-		b := message.Begin{RawMessage: raw,}
+		b := message.Begin{RawMessage: raw}
 
 		b.FinalLSN = d.lsn()
 		b.Timestamp = d.timestamp()
@@ -106,7 +106,7 @@ func Parse(src []byte) (message.Message, error) {
 		return b, nil
 
 	case 'C':
-		c := message.Commit{RawMessage: raw,}
+		c := message.Commit{RawMessage: raw}
 
 		c.Flags = d.uint8()
 		c.LSN = d.lsn()
@@ -115,13 +115,13 @@ func Parse(src []byte) (message.Message, error) {
 		return c, nil
 
 	case 'O':
-		o := message.Origin{RawMessage: raw,}
+		o := message.Origin{RawMessage: raw}
 		o.LSN = d.lsn()
 		o.Name = d.string()
 		return o, nil
 
 	case 'R':
-		r := message.Relation{RawMessage: raw,}
+		r := message.Relation{RawMessage: raw}
 
 		r.OID = d.oid()
 		r.Namespace = d.string()
@@ -131,7 +131,7 @@ func Parse(src []byte) (message.Message, error) {
 		return r, nil
 
 	case 'Y':
-		t := message.Type{RawMessage: raw,}
+		t := message.Type{RawMessage: raw}
 
 		t.OID = d.oid()
 		t.Namespace = d.string()
@@ -139,7 +139,7 @@ func Parse(src []byte) (message.Message, error) {
 		return t, nil
 
 	case 'I':
-		i := message.Insert{RawMessage: raw,}
+		i := message.Insert{RawMessage: raw}
 
 		i.RelationOID = d.oid()
 		if d.uint8() == 'N' {
@@ -148,7 +148,7 @@ func Parse(src []byte) (message.Message, error) {
 		return i, nil
 
 	case 'U':
-		u := message.Update{RawMessage: raw,}
+		u := message.Update{RawMessage: raw}
 
 		u.RelationOID = d.oid()
 		char := d.uint8()
@@ -165,7 +165,7 @@ func Parse(src []byte) (message.Message, error) {
 		return u, nil
 
 	case 'D':
-		m := message.Delete{RawMessage: raw,}
+		m := message.Delete{RawMessage: raw}
 
 		m.RelationOID = d.oid()
 		char := d.uint8()
@@ -175,7 +175,7 @@ func Parse(src []byte) (message.Message, error) {
 		return m, nil
 
 	case 'T':
-		t := message.Truncate{RawMessage: raw,}
+		t := message.Truncate{RawMessage: raw}
 
 		relationsCnt := int(d.uint32())
 		options := d.uint8()

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -22,9 +22,9 @@ const (
 	ReplicaIdentityIndex                   = 'i'
 	ReplicaIdentityFull                    = 'f'
 
-	TupleNull    TupleKind = 'n' // Identifies the data as NULL value.
-	TupleUnchanged         = 'u' // Identifies unchanged TOASTed value (the actual value is not sent).
-	TupleText              = 't' // Identifies the data as text formatted value.
+	TupleNull      TupleKind = 'n' // Identifies the data as NULL value.
+	TupleUnchanged           = 'u' // Identifies unchanged TOASTed value (the actual value is not sent).
+	TupleText                = 't' // Identifies the data as text formatted value.
 
 	MsgInsert MType = iota
 	MsgUpdate
@@ -74,16 +74,16 @@ type Message interface {
 
 type RawMessage struct {
 	Message
-	Data    []byte
+	Data []byte
 }
 
 func (m RawMessage) RawData() []byte {
-	return m.Data;
+	return m.Data
 }
 
 type NamespacedName struct {
-	Namespace string    `yaml:"Namespace"`
-	Name      string    `yaml:"Name"`
+	Namespace string `yaml:"Namespace"`
+	Name      string `yaml:"Name"`
 }
 
 type Column struct {
@@ -121,7 +121,7 @@ type Origin struct {
 
 type Relation struct {
 	RawMessage
-	NamespacedName                  `yaml:"NamespacedName"`
+	NamespacedName `yaml:"NamespacedName"`
 
 	OID             dbutils.OID     `yaml:"OID"`             // OID of the relation.
 	ReplicaIdentity ReplicaIdentity `yaml:"ReplicaIdentity"` // Replica identity
@@ -245,7 +245,7 @@ func joinTupleData(values []TupleData, delimiter string) string {
 		if !first {
 			b.WriteString(delimiter)
 		} else {
-			first = false;
+			first = false
 		}
 
 		b.WriteString(v.String())


### PR DESCRIPTION
Attempt to simplify and improve readability of the code.

Also one important bugfix related to replaying (restoring) `delete` messages that contain `NULL`'s in conditions. You can reproduce it this way:
```sql
create table abc (a int, b int);
insert ... -- something
```
Run `./backup`.
```sql
insert into abc values (123, 456);
insert into abc values (123, null);
delete from abc where a = 123 and b is null;
```
Then run `./restore` and see that both rows with `a = 123` in the target table are deleted.